### PR TITLE
Move analyzer and compose plugin to regular deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "coupling-graph": "npx madge --extensions js,jsx,ts,tsx,css,md,mdx ./ --exclude '.next|tailwind.config.js|reset.d.ts|prettier.config.js|postcss.config.js|playwright.config.ts|next.config.js|next-env.d.ts|instrumentation.ts|e2e/|README.md|.storybook/|.eslintrc.js' --image graph.svg"
   },
   "dependencies": {
+    "@next/bundle-analyzer": "^13.3.0",
     "@radix-ui/react-accordion": "^1.1.1",
     "@radix-ui/react-checkbox": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.3",
@@ -49,6 +50,7 @@
     "class-variance-authority": "^0.6.0",
     "lodash": "^4.17.21",
     "next": "^13.3.0",
+    "next-compose-plugins": "^2.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tailwind-merge": "^1.10.0",
@@ -57,7 +59,6 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@jest/globals": "^29.5.0",
-    "@next/bundle-analyzer": "^13.3.0",
     "@opentelemetry/api": "^1.4.1",
     "@playwright/test": "^1.32.3",
     "@storybook/addon-essentials": "^7.0.5",
@@ -89,7 +90,6 @@
     "fetch-mock": "^9.11.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
-    "next-compose-plugins": "^2.2.1",
     "patch-package": "^7.0.0",
     "postcss": "^8.4.21",
     "postinstall-postinstall": "^2.1.0",


### PR DESCRIPTION
If running both `yarn install` and `yarn build` with `NODE_ENV=production` it comes up with
```sh
antonio:~/Development/next-enterprise ▶ NODE_ENV=production yarn build
yarn run v1.22.19
$ next build
- error Failed to load next.config.mjs, see more info here https://nextjs.org/docs/messages/next-config-error

> Build error occurred
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@next/bundle-analyzer' imported from /Users/antonio/Development/next-enterprise/next.config.mjs
    at new NodeError (node:internal/errors:399:5)
    at packageResolve (node:internal/modules/esm/resolve:889:9)
    at moduleResolve (node:internal/modules/esm/resolve:938:20)
    at defaultResolve (node:internal/modules/esm/resolve:1153:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:838:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:77:40)
    at link (node:internal/modules/esm/module_job:76:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This PR simply moves these to the regular dependencies which makes it so that they are installed in production environment as well.
Usually not noticeable in local dev, but happens when building a production version in CI for example