### PR TITLE
lint tailwind fix

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,7 +50,7 @@ export default function Web() {
           <div className="justify-center space-y-8 md:grid md:grid-cols-2 md:gap-12 md:space-y-0 lg:grid-cols-3">
             {LP_GRID_ITEMS.map((singleItem) => (
               <div key={singleItem.title} className="flex flex-col items-center justify-center text-center">
-                <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-primary-100 p-1.5 text-blue-700 dark:bg-primary-900 lg:h-12 lg:w-12">
+                <div className="mb-4 flex  size-10  items-center justify-center rounded-full bg-primary-100 p-1.5 text-blue-700 dark:bg-primary-900 lg:size-12 ">
                   {singleItem.icon}
                 </div>
                 <h3 className="mb-2 text-xl font-bold dark:text-white">{singleItem.title}</h3>


### PR DESCRIPTION
Fix a lint error in the tailwind classname 


./app/page.tsx
53:22  Warning: Classnames 'h-10, w-10' could be replaced by the 'size-10' shorthand!  tailwindcss/enforces-shorthand
53:22  Warning: Classnames 'lg:h-12, lg:w-12' could be replaced by the 'lg:size-12' shorthand!  tailwindcss/enforces-shorthand