### PR TITLE
tailwind css lint fix classname

### DIFF
--- a/lp-items.tsx
+++ b/lp-items.tsx
@@ -9,7 +9,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className=" size-6"
       >
         <path
           strokeLinecap="round"
@@ -29,7 +29,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -49,7 +49,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
       </svg>
@@ -65,7 +65,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -85,7 +85,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -105,7 +105,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -125,7 +125,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -145,7 +145,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -165,7 +165,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -185,7 +185,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -205,7 +205,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -226,7 +226,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -246,7 +246,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -266,7 +266,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -286,7 +286,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -306,7 +306,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -326,7 +326,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -346,7 +346,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 6a7.5 7.5 0 107.5 7.5h-7.5V6z" />
         <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0013.5 3v7.5z" />
@@ -363,7 +363,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -383,7 +383,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"
@@ -403,7 +403,7 @@ export const LP_GRID_ITEMS = [
         viewBox="0 0 24 24"
         strokeWidth={1.5}
         stroke="currentColor"
-        className="h-6 w-6"
+        className="size-6"
       >
         <path
           strokeLinecap="round"


### PR DESCRIPTION
Replaces multiple Tailwind CSS classnames by their shorthand (enforces-shorthand).  Eslint enforcement.
